### PR TITLE
CI-6141: Enable packaging for pxf-fdw7

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -18,8 +18,8 @@ concurrency:
 env:
   MATRIX_BUILDS_PR: |
     [
-      { "version": "6", "target_os": "ubuntu", "target_os_version": "22.04", "release": "prod"  },
-      { "version": "7", "target_os": "ubuntu", "target_os_version": "22.04", "release": "prod",  "skip_package": "true" }
+      { "version": "6", "target_os": "ubuntu", "target_os_version": "22.04", "release": "prod" },
+      { "version": "7", "target_os": "ubuntu", "target_os_version": "22.04", "release": "prod" }
     ]
   MATRIX_BUILDS_NIGHTLY: |
     [

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -56,10 +56,10 @@ jobs:
           cat > /tmp/builds_nightly.json << 'JSON_END'
           ${{ env.MATRIX_BUILDS_NIGHTLY }}
           JSON_END
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            cp /tmp/builds_pr.json /tmp/builds.json
-          else
+          if [ "${{ github.event_name }}" = "schedule" ]; then
             cp /tmp/builds_nightly.json /tmp/builds.json
+          else
+            cp /tmp/builds_pr.json /tmp/builds.json
           fi
           echo "matrix=$(jq -c . /tmp/builds.json)" >> $GITHUB_OUTPUT
 
@@ -72,6 +72,7 @@ jobs:
           echo "tests=$(jq -c . /tmp/tests.json)" >> $GITHUB_OUTPUT
 
   package:
+    if: github.event_name != 'schedule'
     needs: generate-matrix
     name: Create packages
     uses: ./.github/workflows/greengage-reusable-package.yml

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -19,12 +19,12 @@ env:
   MATRIX_BUILDS_PR: |
     [
       { "version": "6", "target_os": "ubuntu", "target_os_version": "22.04", "release": "prod" },
-      { "version": "7", "target_os": "ubuntu", "target_os_version": "22.04", "release": "prod" }
+      { "version": "7", "target_os": "ubuntu", "target_os_version": "22.04", "release": "prod" },
+      { "version": "6", "target_os": "ubuntu", "target_os_version": "24.04", "release": "prod", "skip_package": "true" }
     ]
   MATRIX_BUILDS_NIGHTLY: |
     [
       { "version": "6", "target_os": "ubuntu", "target_os_version": "22.04", "release": "devel", "skip_package": "true" },
-      { "version": "6", "target_os": "ubuntu", "target_os_version": "24.04", "release": "prod",  "skip_package": "true" },
       { "version": "6", "target_os": "ubuntu", "target_os_version": "24.04", "release": "devel", "skip_package": "true" },
       { "version": "7", "target_os": "ubuntu", "target_os_version": "22.04", "release": "devel", "skip_package": "true" }
     ]

--- a/.github/workflows/greengage-release.yml
+++ b/.github/workflows/greengage-release.yml
@@ -19,10 +19,10 @@ jobs:
           target_os_version: 24.04
           extensions:  deb ddeb
           artifact_prefix: deb-packages-pxf6
-        # - target_os: ubuntu
-        #   target_os_version: 22.04
-        #   extensions:  deb ddeb
-        #   artifact_prefix: deb-packages-pxf7
+        - target_os: ubuntu
+          target_os_version: 22.04
+          extensions:  deb ddeb
+          artifact_prefix: deb-packages-pxf7
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/greengage-reusable-package.yml
+++ b/.github/workflows/greengage-reusable-package.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Test install deb-packages in Docker 
         if: ${{ matrix.skip_package != 'true' }}
-        uses: greengagedb/greengage-ci/.github/actions/tests/install/deb@v44
+        uses: greengagedb/greengage-ci/.github/actions/tests/install/deb@v45
         with:
           test_docker: ${{ matrix.target_os}}:${{ matrix.target_os_version }}
           artifact_name: ${{ env.DEB_PACKAGES }}

--- a/.github/workflows/greengage-reusable-package.yml
+++ b/.github/workflows/greengage-reusable-package.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deb-packages:
-    name: deb with ${{ matrix.release }}${{ matrix.tag && format(' {0}', matrix.tag) }} greengage${{ matrix.version }} for ${{ matrix.target_os }} ${{ matrix.target_os_version }}
+    name: ${{ matrix.skip_package == 'true' && '[SKIPPED] ' || '' }}deb with ${{ matrix.release }}${{ matrix.tag && format(' {0}', matrix.tag) }} greengage${{ matrix.version }} for ${{ matrix.target_os }} ${{ matrix.target_os_version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -24,7 +24,15 @@ jobs:
     steps:
       - name: Skip notify
         if: ${{ matrix.skip_package == 'true' }}
-        run: echo "Job will be skipped due to flag 'skip_package'"
+        run: |
+          echo "### ⏭️ Packaging Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "This matrix job was intentionally skipped due to the \`skip_package: true\` flag." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Configuration:**" >> $GITHUB_STEP_SUMMARY
+          echo "- **Target OS:** ${{ matrix.target_os }} ${{ matrix.target_os_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Release:** ${{ matrix.release }}${{ matrix.tag && format(' (tag: {0})', matrix.tag) || '' }}" >> $GITHUB_STEP_SUMMARY
+          
+          echo "::notice title=Skipped Process::Build and packaging are disabled for this configuration."
 
       - uses: actions/checkout@v6
         if: ${{ matrix.skip_package != 'true' }}

--- a/debian/control.in
+++ b/debian/control.in
@@ -2,7 +2,6 @@ Source: pxf
 Maintainer: Greengage <greengage@greengagedb.org>
 Section: database
 Build-Depends: debhelper (>= 13),
-	dh-python,
 	lsb-release
 Description: The PXF package with FDW extension provides connection pool for the Greengage Database
 	PXF is an extensible framework that allows a distributed database like


### PR DESCRIPTION
## Enable packaging for pxf-fdw7 (#10)

### Task

- add version 7 / ubuntu 22.04 entry to the PR build matrix
- uncomment the deb-packages-pxf7 matrix entry in the Release workflow
- remove dh-python build dependency, since no Python code is packaged
  and the dh-python helpers are never invoked

### Additional changes (out of scope, done at reviewer's discretion)

- improve observability for skipped packaging jobs: prefix job name
  with [SKIPPED], write a summary to GITHUB_STEP_SUMMARY, emit a
  workflow notice annotation
- bump tests/install/deb action v44 to v45 (download-artifact v4 to
  v8, Node 24 support)
- move the 6 / ubuntu 24.04 prod build from nightly matrix to PR
  matrix only: repeating it nightly against an unchanged image adds
  no value
- invert build matrix condition so schedule triggers use the nightly
  matrix and everything else (PR/release) uses the PR matrix; skip
  the package job on schedule so nightly runs tests only

Task: [CI-6141](https://tracker.yandex.ru/CI-6141)